### PR TITLE
CML-1: Void Common Lab Test Entities after an Order in OpenMRS is voided

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>commonlabtest</artifactId>
-		<version>1.3.1</version>
+		<version>1.3.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commonlabtest-api</artifactId>

--- a/api/src/main/java/org/openmrs/module/commonlabtest/aop/AfterOrderVoidAdvice.java
+++ b/api/src/main/java/org/openmrs/module/commonlabtest/aop/AfterOrderVoidAdvice.java
@@ -1,0 +1,89 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.commonlabtest.aop;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.Encounter;
+import org.openmrs.Order;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.commonlabtest.LabTest;
+import org.openmrs.module.commonlabtest.api.CommonLabTestService;
+import org.springframework.aop.AfterReturningAdvice;
+
+/**
+ * @author tahira.niazi@ihsinformatics.com
+ */
+
+public class AfterOrderVoidAdvice implements AfterReturningAdvice {
+
+	private Log log = LogFactory.getLog(this.getClass());
+
+	/*
+	 * (non-Javadoc) * @see
+	 * org.springframework.aop.AfterReturningAdvice#afterReturning(java.lang.
+	 * Object, java.lang.reflect.Method, java.lang.Object[], java.lang.Object)
+	 * 
+	 * depends on org.openmrs.api.impl.OrderServiceImpl
+	 */
+	@Override
+	public void afterReturning(Object returnValue, Method method, Object[] args, Object target) throws Throwable {
+
+		Logger.getAnonymousLogger().info("======== in After Advice " + method.getName() + "========");
+		CommonLabTestService commonLabTestService;
+
+		if (method.getName().equalsIgnoreCase("voidEncounter")) {
+			if (returnValue != null) {
+
+				Encounter encounter = (Encounter) returnValue;
+				Set<Order> orders = (Set<Order>) encounter.getOrders();
+
+				for (Order o : orders) {
+					if (o.getVoided()) {
+						Logger.getAnonymousLogger().info(" ==== > Order # " + o.getOrderId() + " Voided: " + o.getVoided());
+						// void corresponding LabTest entity that has one to one mapping to this Order
+						commonLabTestService = Context.getService(CommonLabTestService.class);
+						LabTest labTest = commonLabTestService.getLabTest(o.getOrderId());
+						if (labTest != null) {
+							commonLabTestService.voidLabTest(labTest, o.getVoidReason());
+							Logger.getAnonymousLogger().info(
+							    " ==== > Lab Test # " + labTest.getTestOrderId() + " Voided: " + labTest.getVoided());
+						}
+					}
+				}
+			}
+
+		} else if (method.getName().equalsIgnoreCase("unvoidEncounter")) {
+			if (returnValue != null) {
+
+				Encounter encounter = (Encounter) returnValue;
+				Set<Order> orders = (Set<Order>) encounter.getOrders();
+
+				for (Order o : orders) {
+					if (!o.getVoided()) {
+						Logger.getAnonymousLogger().info(" ==== > Order # " + o.getOrderId() + " Voided: " + o.getVoided());
+						// unvoid corresponding LabTest entity that has one to one mapping to this Order
+						commonLabTestService = Context.getService(CommonLabTestService.class);
+						LabTest labTest = commonLabTestService.getLabTest(o.getOrderId());
+						if (labTest != null) {
+							commonLabTestService.unvoidLabTest(labTest);
+							Logger.getAnonymousLogger().info(
+							    " ==== > Lab Test # " + labTest.getTestOrderId() + " Voided: " + labTest.getVoided());
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/api/src/main/java/org/openmrs/module/commonlabtest/api/dao/impl/CommonLabTestDAOImpl.java
+++ b/api/src/main/java/org/openmrs/module/commonlabtest/api/dao/impl/CommonLabTestDAOImpl.java
@@ -316,7 +316,7 @@ public class CommonLabTestDAOImpl implements CommonLabTestDAO {
 			criteria.add(Restrictions.between("dateCreated", from, to));
 		}
 		if (!includeVoided) {
-			criteria.add(Restrictions.eq("voided", false));
+			criteria.add(Restrictions.eq("o.voided", false));
 		}
 		criteria.addOrder(Order.asc("testOrderId")).addOrder(Order.asc("voided")).list();
 		return criteria.list();

--- a/api/src/test/java/org/openmrs/module/commonlabtest/aop/OrderVoidAdvisorTest.java
+++ b/api/src/test/java/org/openmrs/module/commonlabtest/aop/OrderVoidAdvisorTest.java
@@ -1,0 +1,134 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.commonlabtest.aop;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import java.util.Set;
+
+import org.openmrs.Encounter;
+import org.openmrs.Order;
+import org.openmrs.api.EncounterService;
+import org.openmrs.api.OrderService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.commonlabtest.LabTest;
+import org.openmrs.module.commonlabtest.LabTestAttribute;
+import org.openmrs.module.commonlabtest.LabTestSample;
+import org.openmrs.module.commonlabtest.aop.common.AOPContextSensitiveTest;
+import org.openmrs.module.commonlabtest.aop.common.TestAOP;
+import org.openmrs.module.commonlabtest.api.CommonLabTestService;
+
+/**
+ * @author tahira.niazi@ihsinformatics.com
+ */
+public class OrderVoidAdvisorTest extends AOPContextSensitiveTest {
+
+	private EncounterService encounterService;
+
+	private OrderService orderService;
+
+	private CommonLabTestService commonLabTestService;
+
+	private static final int DEMO_ENCOUNTER_ID = 1000;
+
+	private static final int DEMO_ORDER1_ID = 100;
+
+	private static final int DEMO_ORDER2_ID = 200;
+
+	private static final int DEMO_LAB_TEST_ID = 100;
+
+	private static final int DEMO_LAB_TEST_SAMPLE_ID = 1;
+
+	private static final int DEMO_LAB_TEST_ATTRIBUTE1_ID = 1;
+
+	private static final int DEMO_LAB_TEST_ATTRIBUTE2_ID = 2;
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.openmrs.module.commonlabtest.aop.AOPContextSensitiveTest#
+	 * setInterceptorAndServices(org.openmrs.module.commonlabtest.aop.TestWithAOP)
+	 */
+	@Override
+	protected void setInterceptorAndServices(TestAOP testCase) {
+		testCase.setAspect(AfterOrderVoidAdvice.class);
+		testCase.addService(EncounterService.class);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		encounterService = Context.getEncounterService();
+		orderService = Context.getOrderService();
+		commonLabTestService = Context.getService(CommonLabTestService.class);
+
+	}
+
+	@Test
+	public void voidEncounter_voidingLinkedOrderShouldVoidLabTest() {
+
+		Encounter encounter = encounterService.getEncounter(DEMO_ENCOUNTER_ID);
+		Order order1 = orderService.getOrder(DEMO_ORDER1_ID);
+		Order order2 = orderService.getOrder(DEMO_ORDER2_ID);
+		LabTest labTest = commonLabTestService.getLabTest(DEMO_LAB_TEST_ID);
+		LabTestSample labTestSample = commonLabTestService.getLabTestSample(DEMO_LAB_TEST_SAMPLE_ID);
+		LabTestAttribute labTestAttribute1 = commonLabTestService.getLabTestAttribute(DEMO_LAB_TEST_ATTRIBUTE1_ID);
+		LabTestAttribute labTestAttribute2 = commonLabTestService.getLabTestAttribute(DEMO_LAB_TEST_ATTRIBUTE2_ID);
+
+		Encounter encounter1 = encounterService.voidEncounter(encounter, "Testing AOP");
+		assertNotNull(encounter1);
+
+		assertTrue(order1.getVoided());
+
+		assertTrue(order2.getVoided());
+
+		assertTrue(labTest.getVoided());
+
+		assertTrue(labTestSample.getVoided());
+
+		assertTrue(labTestAttribute1.getVoided());
+
+		assertTrue(labTestAttribute2.getVoided());
+
+	}
+
+	@Test
+	public void unvoidEncounter_unvoidingLinkedOrderShouldUnVoidLabTest() {
+
+		Encounter encounter = encounterService.getEncounter(DEMO_ENCOUNTER_ID);
+		Order order1 = orderService.getOrder(DEMO_ORDER1_ID);
+		Order order2 = orderService.getOrder(DEMO_ORDER2_ID);
+		LabTest labTest = commonLabTestService.getLabTest(DEMO_LAB_TEST_ID);
+		LabTestSample labTestSample = commonLabTestService.getLabTestSample(DEMO_LAB_TEST_SAMPLE_ID);
+		LabTestAttribute labTestAttribute1 = commonLabTestService.getLabTestAttribute(DEMO_LAB_TEST_ATTRIBUTE1_ID);
+		LabTestAttribute labTestAttribute2 = commonLabTestService.getLabTestAttribute(DEMO_LAB_TEST_ATTRIBUTE2_ID);
+
+		Encounter encounter1 = encounterService.unvoidEncounter(encounter);
+		assertNotNull(encounter1);
+
+		assertFalse(order1.getVoided());
+
+		assertFalse(order2.getVoided());
+
+		assertFalse(labTest.getVoided());
+
+		assertFalse(labTestSample.getVoided());
+
+		assertFalse(labTestAttribute1.getVoided());
+
+		assertFalse(labTestAttribute2.getVoided());
+
+	}
+
+}

--- a/api/src/test/java/org/openmrs/module/commonlabtest/aop/common/AOPContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/module/commonlabtest/aop/common/AOPContextSensitiveTest.java
@@ -1,0 +1,105 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.commonlabtest.aop.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.aopalliance.aop.Advice;
+import org.junit.After;
+import org.junit.Before;
+import org.openmrs.api.OpenmrsService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.AdvicePoint;
+import org.openmrs.module.commonlabtest.CommonLabTestBase;
+import org.springframework.aop.AfterReturningAdvice;
+
+/**
+ * @author tahira.niazi@ihsinformatics.com
+ */
+public abstract class AOPContextSensitiveTest extends CommonLabTestBase implements TestAOP {
+
+	private Class<?> adviceClass;
+
+	private AfterReturningAdvice afterAdvice;
+
+	private Map<Class<?>, Advice> servicesMap = new HashMap<Class<?>, Advice>();
+
+	@Before
+	public void runBeforeEachTest() throws Exception {
+		super.initTestData();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.openmrs.module.commonlabtest.aop.common.TestWithAOP#setAspect(java.lang.
+	 * Class)
+	 */
+	@Override
+	public void setAspect(Class<? extends AfterReturningAdvice> adviceClass) {
+		this.adviceClass = adviceClass;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.openmrs.module.commonlabtest.aop.common.TestWithAOP#setAspect(org.
+	 * springframework.aop.AfterReturningAdvice)
+	 */
+	@Override
+	public void setAspect(AfterReturningAdvice advice) {
+		this.afterAdvice = advice;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.openmrs.module.commonlabtest.aop.common.TestWithAOP#addService(java.lang.
+	 * Class)
+	 */
+	@Override
+	public void addService(Class<? extends OpenmrsService> serviceClass) {
+		servicesMap.put(serviceClass, null);
+	}
+
+	abstract protected void setInterceptorAndServices(TestAOP testCase);
+
+	@Before
+	public void setupAOP() throws Exception {
+
+		setInterceptorAndServices(this);
+
+		for (Class<?> serviceClass : servicesMap.keySet()) {
+			Advice advice;
+			if (adviceClass != null) {
+				advice = (Advice) (new AdvicePoint(serviceClass.getCanonicalName(),
+				        Context.loadClass(adviceClass.getCanonicalName()))).getClassInstance();
+			} else if (afterAdvice != null) {
+				advice = afterAdvice;
+			} else {
+				throw new IllegalStateException("You must either set advice or advice class to setup the Context");
+			}
+
+			servicesMap.put(serviceClass, advice);
+			Context.addAdvice(Context.loadClass(serviceClass.getCanonicalName()), advice);
+		}
+	}
+
+	@After
+	public void tearDownAOP() throws Exception {
+		for (Class<?> serviceClass : servicesMap.keySet()) {
+			Context.removeAdvice(Context.loadClass(serviceClass.getCanonicalName()), servicesMap.get(serviceClass));
+		}
+	}
+
+}

--- a/api/src/test/java/org/openmrs/module/commonlabtest/aop/common/TestAOP.java
+++ b/api/src/test/java/org/openmrs/module/commonlabtest/aop/common/TestAOP.java
@@ -1,0 +1,41 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.commonlabtest.aop.common;
+
+import org.openmrs.api.OpenmrsService;
+import org.springframework.aop.AfterReturningAdvice;
+
+/**
+ * @author tahira.niazi@ihsinformatics.com
+ */
+public interface TestAOP {
+
+	/**
+	 * Sets an AOP advice class to be active on the test case.
+	 * 
+	 * @param afterAdviceClass
+	 */
+	void setAspect(Class<? extends AfterReturningAdvice> afterAdviceClass);
+
+	/**
+	 * Sets an AOP advice class to be active on the test case.
+	 * 
+	 * @param afterAdvice
+	 */
+	void setAspect(AfterReturningAdvice afterAdvice);
+
+	/**
+	 * Hooks the OpenMRS Services
+	 * 
+	 * @param serviceClass
+	 */
+	void addService(Class<? extends OpenmrsService> serviceClass);
+
+}

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>commonlabtest</artifactId>
-		<version>1.3.1</version>
+		<version>1.3.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commonlabtest-omod</artifactId>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -39,12 +39,11 @@
 	</aware_of_modules>
 	
 	
-	<!-- AOP
+	<!--  AOP Support -->
 	<advice>
-		<point>org.openmrs.api.FormService</point>
-		<class>@MODULE_PACKAGE@.advice.DuplicateFormAdvisor</class>
+		<point>org.openmrs.api.EncounterService</point>
+		<class>org.openmrs.module.commonlabtest.aop.AfterOrderVoidAdvice</class>
 	</advice>
-	 /AOP -->
 	
 	
 	<!-- Required Privileges -->

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>commonlabtest</artifactId>
-	<version>1.3.1</version>
+	<version>1.3.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Common Lab Test</name>
 	<description>Basic module to manage Laboratory tests</description>
@@ -20,7 +20,7 @@
 	    <connection>scm:git:https://github.com/openmrs/openmrs-module-commonlabtest</connection>
 	    <developerConnection>scm:git:https://github.com/openmrs/openmrs-module-commonlabtest</developerConnection>
 	    <url>https://github.com/openmrs/openmrs-module-commonlabtest</url>
-	  <tag>1.3.1</tag>
+	  <tag>HEAD</tag>
   </scm>
 	
 	<distributionManagement>


### PR DESCRIPTION
### **Description of what I changed**

- Implemented an aspect based on After Advice to monitor voiding/unvoiding of OpenMRS Orders and then voiding/unvoiding linked LabTest objects accordingly.

- Implemented units tests for this advice.

### **Issues I worked on**
see https://issues.openmrs.org/browse/CLM-1

### **Checklist: I completed these to help reviewers :)**

-  [x] My pull request only contains ONE single commit
(the number above, next to the 'Commits' tab is 1).

No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [x] My IDE is configured to follow the [code style](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

No? Unsure? -> [configure your IDE,](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE) format the code and add the changes with `git add . && git commit --amend`

- [x] I have added tests to cover my changes. (If you refactored
existing code that was well tested you do not have to add tests)

No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
added all formatting changes to my commit.

No? -> execute above command

- [x] All new and existing **tests passed**.

No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

No? Unsure? -> execute command `git pull --rebase upstream master`