### PR TITLE
TRUNK-5699 Deprecate Attributable#findPossibleValues() and Attributable#getPossibleValues()

### DIFF
--- a/api/src/main/java/org/openmrs/module/commonlabtest/LabTest.java
+++ b/api/src/main/java/org/openmrs/module/commonlabtest/LabTest.java
@@ -132,8 +132,11 @@ public class LabTest extends BaseCustomizableData<LabTestAttribute> implements j
 	 * 
 	 * @param referenceNumber the reference number
 	 * @return {@link LabTest} object(s)
+	 * @deprecated Data provided by this method can be better achieved from 
+	 * appropriate service at point of use.
 	 */
 	@Override
+	@Deprecated
 	public List<LabTest> findPossibleValues(String referenceNumber) {
 		try {
 			return Context.getService(CommonLabTestService.class).getLabTests(referenceNumber, false);
@@ -153,8 +156,11 @@ public class LabTest extends BaseCustomizableData<LabTestAttribute> implements j
 	 * Also @see org.openmrs.Attributable#getPossibleValues()
 	 * 
 	 * @return {@link LabTest} object(s)
+	 * @deprecated Data provided by this method can be better achieved from 
+	 * appropriate service at point of use.
 	 */
 	@Override
+	@Deprecated
 	public List<LabTest> getPossibleValues() {
 		return Collections.emptyList();
 	}


### PR DESCRIPTION
## Description of what I changed
Deprecated the methods `Attributable#findPossibleValues()` and `Attributable#getPossibleValues()`


## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-5699