### PR TITLE
CLM-8: Avoid creating duplicate attributes when adding result for CommonLabTest Order

### DIFF
--- a/api/src/main/java/org/openmrs/module/commonlabtest/LabTest.java
+++ b/api/src/main/java/org/openmrs/module/commonlabtest/LabTest.java
@@ -132,8 +132,8 @@ public class LabTest extends BaseCustomizableData<LabTestAttribute> implements j
 	 * 
 	 * @param referenceNumber the reference number
 	 * @return {@link LabTest} object(s)
-	 * @deprecated Data provided by this method can be better achieved from 
-	 * appropriate service at point of use.
+	 * @deprecated Data provided by this method can be better achieved from appropriate service at point
+	 *             of use.
 	 */
 	@Override
 	@Deprecated
@@ -156,8 +156,8 @@ public class LabTest extends BaseCustomizableData<LabTestAttribute> implements j
 	 * Also @see org.openmrs.Attributable#getPossibleValues()
 	 * 
 	 * @return {@link LabTest} object(s)
-	 * @deprecated Data provided by this method can be better achieved from 
-	 * appropriate service at point of use.
+	 * @deprecated Data provided by this method can be better achieved from appropriate service at point
+	 *             of use.
 	 */
 	@Override
 	@Deprecated
@@ -218,6 +218,28 @@ public class LabTest extends BaseCustomizableData<LabTestAttribute> implements j
 		} else {
 			return "";
 		}
+	}
+
+	/**
+	 * Returns the first non-voided commonlabtest attribute matching a commonlabtest attribute type.
+	 * <br>
+	 * <br>
+	 * Returns null if this commonlabtest has no non-voided {@link LabTestAttribute} with the given
+	 * {@link LabTestAttributeType}, the given {@link LabTestAttributeType} is null, or this
+	 * commonlabtest has no attributes.
+	 * 
+	 * @param lat the LabTestAttributeType to look for {@link LabTestAttributeType#equals(Object)}
+	 * @return LabTestAttribute that matches the given type
+	 */
+	public LabTestAttribute getAttribute(LabTestAttributeType lat) {
+		if (lat != null) {
+			for (LabTestAttribute attribute : getAttributes()) {
+				if (lat.equals(attribute.getAttributeType()) && !attribute.getVoided()) {
+					return attribute;
+				}
+			}
+		}
+		return null;
 	}
 
 	public Integer getTestOrderId() {

--- a/omod/src/main/java/org/openmrs/module/commonlabtest/web/resource/LabTestOrderResourceController.java
+++ b/omod/src/main/java/org/openmrs/module/commonlabtest/web/resource/LabTestOrderResourceController.java
@@ -165,10 +165,26 @@ public class LabTestOrderResourceController extends DataDelegatingCrudResource<L
 		return labTest.getLabReferenceNumber();
 	}
 
+	/**
+	 * Sets attributes on the given CommonLabbTest order.
+	 * 
+	 * @param instance
+	 * @param attrs
+	 */
 	@PropertySetter("attributes")
-	public static void setAttributes(LabTest instance, List<LabTestAttribute> attributes) {
-		for (LabTestAttribute attribute : attributes) {
-			instance.addAttribute(attribute);
+	public void setAttributes(LabTest instance, List<LabTestAttribute> attributes) {
+		for (LabTestAttribute attr : attributes) {
+			LabTestAttribute existingAttribute = instance
+			        .getAttribute(commonLabTestService.getLabTestAttributeTypeByUuid(attr.getAttributeType().getUuid()));
+			if (existingAttribute != null) {
+				if (attr.getValue() == null) {
+					instance.removeLabTestAttribute(existingAttribute);
+				} else {
+					existingAttribute.setValue(attr.getValue());
+				}
+			} else {
+				instance.addAttribute(attr);
+			}
 		}
 	}
 


### PR DESCRIPTION
### Description of what I changed
Avoid creating duplicate attributes when adding result for CommonLabTest Order

Issue I worked on
see https://issues.openmrs.org/browse/CLM-8