### PR TITLE
Fixed CLM-21

### DIFF
--- a/omod/src/main/java/org/openmrs/module/commonlabtest/web/controller/LabTestOrderPortletController.java
+++ b/omod/src/main/java/org/openmrs/module/commonlabtest/web/controller/LabTestOrderPortletController.java
@@ -54,7 +54,7 @@ public class LabTestOrderPortletController extends PortletController {
 						childJsonObject.addProperty("encounterType",
 						    labTest.getOrder().getEncounter().getEncounterType().getName().toString());
 						childJsonObject.addProperty("changedBy",
-						    (labTest.getChangedBy() == null) ? "" : labTest.getChangedBy().getName());
+						    (labTest.getChangedBy() == null) ? "" : labTest.getChangedBy().getUsername());
 						childJsonObject.addProperty("uuid", labTest.getUuid());
 						List<LabTestAttribute> labTestAttribute = Context.getService(CommonLabTestService.class)
 						        .getLabTestAttributes(labTest.getTestOrderId());

--- a/omod/src/main/java/org/openmrs/module/commonlabtest/web/controller/LabTestRequestController.java
+++ b/omod/src/main/java/org/openmrs/module/commonlabtest/web/controller/LabTestRequestController.java
@@ -64,7 +64,7 @@ public class LabTestRequestController {
 			JsonArray jsonChildArray = new JsonArray();
 			List<LabTestType> labTestTypeList = commonLabTestService.getLabTestTypes(null, null, labTestGroup, null, null,
 			    Boolean.FALSE);
-			if (!(labTestTypeList.size() > 0) || labTestTypeList.equals("") || labTestTypeList.isEmpty()) {
+			if (!(labTestTypeList.size() > 0) || labTestTypeList.isEmpty() || labTestTypeList.isEmpty()) {
 				continue; // skip the current iteration.
 			} else if (labTestTypeList.size() == 1 && labTestGroup.equals(LabTestGroup.OTHER)) {
 				continue;
@@ -137,12 +137,11 @@ public class LabTestRequestController {
 				order.setOrderType(Context.getOrderService().getOrderType(3));
 				order.setDateActivated(encounter.getEncounterDatetime());
 				order.setPatient(Context.getPatientService().getPatient(patientId));
-				Concept concept = Context.getConceptService().getConcept(jsonObject.get("testTypeId").getAsInt());
-				order.setConcept(concept);
+				LabTestType labTestType = commonLabTestService.getLabTestType(jsonObject.get("testTypeId").getAsInt());
+				order.setConcept(labTestType.getReferenceConcept());
 				labTest.setOrder(order);
 				labTest.setLabInstructions(jsonObject.get("labInstructions").getAsString());
 				labTest.setLabReferenceNumber(jsonObject.get("labReferenceNumber").getAsString());
-				LabTestType labTestType = commonLabTestService.getLabTestType(jsonObject.get("testTypeId").getAsInt());
 				labTest.setLabTestType(labTestType);
 				labTestArray.add(labTest);
 			}


### PR DESCRIPTION
- Issue: In LabTestRequestController, the order.setConcept() in onSubmit() saved Concept against labTestId instead of the Reference Concept associated with that labTestId
- Also fixed a syntax error caused in LabTestOrderPortletController, which was fetching deprecated getChangedBy().getName() method. Replaced with getChangedBy().getUsername()