### PR TITLE
Implemented search for Samples by various criteria

### DIFF
--- a/api/src/main/java/org/openmrs/module/commonlabtest/api/CommonLabTestService.java
+++ b/api/src/main/java/org/openmrs/module/commonlabtest/api/CommonLabTestService.java
@@ -287,6 +287,24 @@ public interface CommonLabTestService extends OpenmrsService {
 	        throws APIException;
 
 	/**
+	 * Returns a list of {@link LabTestSample} objects by matching the given criteria. At least one of
+	 * the first three parameters must be provided, the rest are optional.
+	 * 
+	 * @param labTest the {@link LabTest} object
+	 * @param patient the {@link Patient} object
+	 * @param sampleIdentifier the identifier of specimen sample
+	 * @param specimenType the {@link Concept} object representing type of specimen
+	 * @param status the {@link LabTestSampleStatus} enumerated type
+	 * @param orderer the {@link Provider} object
+	 * @param from the start {@link Date} object representing start of date of creation
+	 * @param to the end {@link Date} object representing end of date of creation
+	 * @param includeVoided include retired objects
+	 * @return {@link LabTestSample} object(s)
+	 */
+	List<LabTestSample> getLabTestSamples(LabTest labTest, Patient patient, String sampleIdentifier, Concept specimenType,
+	        LabTestSampleStatus status, Provider collector, Date from, Date to, boolean includeVoided) throws APIException;
+
+	/**
 	 * @param labTestTypeId the generated Id
 	 * @return {@link LabTestType} object(s)
 	 * @throws APIException on Exception

--- a/api/src/main/java/org/openmrs/module/commonlabtest/api/dao/CommonLabTestDAO.java
+++ b/api/src/main/java/org/openmrs/module/commonlabtest/api/dao/CommonLabTestDAO.java
@@ -172,6 +172,24 @@ public interface CommonLabTestDAO {
 	List<LabTestSample> getLabTestSamples(Patient patient, boolean includeVoided);
 
 	/**
+	 * Returns a list of {@link LabTestSample} objects by matching the given criteria. At least one of
+	 * the first three parameters must be provided, the rest are optional.
+	 * 
+	 * @param labTest the {@link LabTest} object
+	 * @param patient the {@link Patient} object
+	 * @param sampleIdentifier the identifier of specimen sample
+	 * @param specimenType the {@link Concept} object representing type of specimen
+	 * @param status the {@link LabTestSampleStatus} enumerated type
+	 * @param orderer the {@link Provider} object
+	 * @param from the start {@link Date} object representing start of date of creation
+	 * @param to the end {@link Date} object representing end of date of creation
+	 * @param includeVoided include retired objects
+	 * @return {@link LabTestSample} object(s)
+	 */
+	List<LabTestSample> getLabTestSamples(LabTest labTest, Patient patient, String sampleIdentifier, Concept specimenType,
+	        LabTestSampleStatus status, Provider collector, Date from, Date to, boolean includeVoided);
+
+	/**
 	 * @param labTestTypeId the generated Id
 	 * @return {@link LabTestType} object
 	 */

--- a/api/src/main/java/org/openmrs/module/commonlabtest/api/impl/CommonLabTestServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/commonlabtest/api/impl/CommonLabTestServiceImpl.java
@@ -283,8 +283,7 @@ public class CommonLabTestServiceImpl extends BaseOpenmrsService implements Comm
 	@Transactional(readOnly = true)
 	public List<LabTestSample> getLabTestSamples(LabTest labTest, Patient patient, LabTestSampleStatus status,
 	        String labSampleIdentifier, Provider collector, Date from, Date to, boolean includeVoided) throws APIException {
-		// TODO
-		return null;
+		return getLabTestSamples(labTest, patient, labSampleIdentifier, null, status, collector, from, to, includeVoided);
 	}
 
 	/*
@@ -338,6 +337,16 @@ public class CommonLabTestServiceImpl extends BaseOpenmrsService implements Comm
 	public List<LabTestSample> getLabTestSamples(LabTestSampleStatus status, Date from, Date to, boolean includeVoided)
 	        throws APIException {
 		return getLabTestSamples(null, null, status, null, null, from, to, includeVoided);
+	}
+
+	@Override
+	@Authorized(CommonLabTestConfig.VIEW_LAB_TEST_SAMPLE_PRIVILEGE)
+	@Transactional(readOnly = true)
+	public List<LabTestSample> getLabTestSamples(LabTest labTest, Patient patient, String sampleIdentifier,
+	        Concept specimenType, LabTestSampleStatus status, Provider collector, Date from, Date to,
+	        boolean includeVoided) {
+		return dao.getLabTestSamples(labTest, patient, sampleIdentifier, specimenType, status, collector, from, to,
+		    includeVoided);
 	}
 
 	/*

--- a/api/src/test/java/org/openmrs/module/commonlabtest/CommonLabTestDAOTest.java
+++ b/api/src/test/java/org/openmrs/module/commonlabtest/CommonLabTestDAOTest.java
@@ -205,6 +205,18 @@ public class CommonLabTestDAOTest extends CommonLabTestBase {
 	}
 
 	@Test
+	public final void testGetLabTestSamples() {
+		List<LabTestSample> list = dao.getLabTestSamples(harryGxp, null, null, null, null, null, null, null, false);
+		assertThat(list, Matchers.hasItem(harrySample));
+		list = dao.getLabTestSamples(null, harry, null, null, null, null, null, null, false);
+		assertThat(list, Matchers.hasItem(harrySample));
+		list = dao.getLabTestSamples(null, harry, null, null, null, null, new Date(0), new Date(), false);
+		assertThat(list, Matchers.hasItem(harrySample));
+		list = dao.getLabTestSamples(null, null, "GXP-IRS12345-1", null, null, null, null, null, false);
+		assertThat(list, Matchers.hasItem(harrySample));
+	}
+
+	@Test
 	public final void testGetLabTestType() {
 		LabTestType retrivedObject = dao.getLabTestType(geneXpert.getId());
 		assertEquals(geneXpert, retrivedObject);


### PR DESCRIPTION
- Added getLabTestSamples() method in DAO and Service
- Implemented Searchable interface in LabTestSampleResourceController and overrid doSearch()
- The criteria added to search by LabOrder, Patient, Collector (Provider), Sample Identifier and date range